### PR TITLE
spin-free 2rdm interface

### DIFF
--- a/pyscf/fciqmcscf/fciqmc.py
+++ b/pyscf/fciqmcscf/fciqmc.py
@@ -812,8 +812,8 @@ def read_neci_two_pdm(fciqmcci, filename, norb, directory='.'):
             # Therefore, all we need to do is to swap the middle two indices.
             ind1 = int(linesp[0]) - 1
             ind2 = int(linesp[2]) - 1
-            ind3 = int(linesp[1]) - 1
-            ind4 = int(linesp[3]) - 1
+            ind3 = int(linesp[3]) - 1
+            ind4 = int(linesp[1]) - 1
             assert(int(ind1) < norb_active)
             assert(int(ind2) < norb_active)
             assert(int(ind3) < norb_active)
@@ -826,6 +826,18 @@ def read_neci_two_pdm(fciqmcci, filename, norb, directory='.'):
             two_pdm_active[ind1, ind2, ind3, ind4] = float(linesp[4])
 
     f.close()
+
+    #fill missing two_pdm_active entries (NECI only saves those not identical by symmetry)
+    ids = numpy.where(two_pdm_active != 0)
+    ids = list(zip(*ids))
+    for id1, id2, id3, id4 in ids:
+        z = two_pdm_active[id1, id2, id3, id4]
+        #hermiticity
+        two_pdm_active[id2, id1, id4, id3] = z
+        #creation / creation and annihilation / annihilation swapping
+        two_pdm_active[id3, id4, id1, id2] = z
+        #hermiticity and creation / creation and annihilation / annihilation swapping
+        two_pdm_active[id4, id3, id2, id1] = z
 
     # In order to add any frozen core, we first need to find the spin-free
     # 1-RDM in the active space.

--- a/pyscf/fciqmcscf/test/test_fciqmcci_n2.py
+++ b/pyscf/fciqmcscf/test/test_fciqmcci_n2.py
@@ -42,12 +42,12 @@ class KnowValues(unittest.TestCase):
     def test_mc2step_4o4e_fci(self):
         mc = mcscf.CASSCF(m, 4, 4)
         emc = mc.mc2step()[0]
-        self.assertAlmostEqual(emc,-108.91378640707609, 7)
+        self.assertAlmostEqual(emc,-108.913786412533, 7)
 
     def test_mc2step_6o6e_fci(self):
         mc = mcscf.CASSCF(m, 6, 6)
         emc = mc.mc2step()[0]
-        self.assertAlmostEqual(emc,-108.98028859357791, 7)
+        self.assertAlmostEqual(emc,-108.980105456114, 7)
 
     def test_mc2step_4o4e_fciqmc_wdipmom(self):
         #nelec is the number of electrons in the active space
@@ -59,7 +59,7 @@ class KnowValues(unittest.TestCase):
         mc.fcisolver.RDMSamples = 5000
 
         emc, e_ci, fcivec, casscf_mo, casscf_mo_e = mc.mc2step()
-        self.assertAlmostEqual(emc,-108.91378666934476, 7)
+        self.assertAlmostEqual(emc,-108.91378783681, 7)
 
         # Calculate dipole moment in casscf_mo basis
         # First find the 1RDM in the full space
@@ -77,7 +77,7 @@ class KnowValues(unittest.TestCase):
         mc.fcisolver = fciqmcscf.FCIQMCCI(mol)
         mc.fcisolver.RDMSamples = 5000
         emc = mc.mc2step()[0]
-        self.assertAlmostEqual(emc,-108.98028859357791, 7)
+        self.assertAlmostEqual(emc,-108.98010536141, 7)
 
 if __name__ == "__main__":
     print("Full Tests for FCIQMC-CASSCF N2")


### PR DESCRIPTION
The spin-free 2rdm output formatting of NECI has been changed. Thus FCIQMC-SCF calculations using PySCF and the latest stable version of NECI gave incorrect numbers. 
The commits in this PR update the spin-free 2rdm reading interface (done by Michael Willatt) and enable GUGA-FCIQMC calculations.